### PR TITLE
tweak uwsgi switches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,11 @@ before_script:
 - 'sync.py >>/tmp/trough-sync-local.out 2>&1 &'
 - sleep 5
 - python -c "import doublethink ; from trough.settings import settings ; rr = doublethink.Rethinker(settings['RETHINKDB_HOSTS']) ; rr.db('trough_configuration').wait().run()"
-- 'uwsgi --http :6444 --route-run=chunked: --master --processes=2 --harakiri=3200 --socket-timeout=3200 --max-requests=50000 --vacuum --die-on-term --wsgi-file scripts/reader.py >>/tmp/trough-read.out 2>&1 &'
-- 'uwsgi --http :6222 --route-run=chunked: --master --processes=2 --harakiri=240 --max-requests=50000 --vacuum --die-on-term --wsgi-file scripts/writer.py >>/tmp/trough-write.out 2>&1 &'
+- 'uwsgi --http :6444 --master --processes=2 --harakiri=3200 --http-timeout=3200 --socket-timeout=3200 --max-requests=50000 --vacuum --die-on-term --wsgi-file scripts/reader.py >>/tmp/trough-read.out 2>&1 &'
+- 'uwsgi --http :6222 ----master --processes=2 --harakiri=240 --http-timeout=240 --max-requests=50000 --vacuum --die-on-term --wsgi-file scripts/writer.py >>/tmp/trough-write.out 2>&1 &'
 - 'sync.py --server >>/tmp/trough-sync-server.out 2>&1 &'
-- 'uwsgi --http :6112 --route-run=chunked: --master --processes=2 --harakiri=20 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:local >>/tmp/trough-segment-manager-local.out 2>&1 &'
-- 'uwsgi --http :6111 --route-run=chunked: --master --processes=2 --harakiri=20 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:server >>/tmp/trough-segment-manager-server.out 2>&1 &'
+- 'uwsgi --http :6112 ----master --processes=2 --harakiri=7200 --http-timeout==7200 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:local >>/tmp/trough-segment-manager-local.out 2>&1 &'
+- 'uwsgi --http :6111 ----master --processes=2 --harakiri=7200 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:server >>/tmp/trough-segment-manager-server.out 2>&1 &'
 
 script:
 - py.test -v tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ before_script:
 - sleep 5
 - python -c "import doublethink ; from trough.settings import settings ; rr = doublethink.Rethinker(settings['RETHINKDB_HOSTS']) ; rr.db('trough_configuration').wait().run()"
 - 'uwsgi --http :6444 --master --processes=2 --harakiri=3200 --http-timeout=3200 --socket-timeout=3200 --max-requests=50000 --vacuum --die-on-term --wsgi-file scripts/reader.py >>/tmp/trough-read.out 2>&1 &'
-- 'uwsgi --http :6222 ----master --processes=2 --harakiri=240 --http-timeout=240 --max-requests=50000 --vacuum --die-on-term --wsgi-file scripts/writer.py >>/tmp/trough-write.out 2>&1 &'
-- 'sync.py --server >>/tmp/trough-sync-server.out 2>&1 &'
-- 'uwsgi --http :6112 ----master --processes=2 --harakiri=7200 --http-timeout==7200 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:local >>/tmp/trough-segment-manager-local.out 2>&1 &'
-- 'uwsgi --http :6111 ----master --processes=2 --harakiri=7200 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:server >>/tmp/trough-segment-manager-server.out 2>&1 &'
+- 'uwsgi --http :6222 --master --processes=2 --harakiri=240 --http-timeout=240 --max-requests=50000 --vacuum --die-on-term --wsgi-file scripts/writer.py >>/tmp/trough-write.out 2>&1 &'
+- 'sync.py --server >>mp/trough-sync-server.out 2>&1 &'
+- 'uwsgi --http :6112 --master --processes=2 --harakiri=7200 --http-timeout==7200 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:local >>/tmp/trough-segment-manager-local.out 2>&1 &'
+- 'uwsgi --http :6111 --master --processes=2 --harakiri=7200 --http-timeout==7200 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:server >>/tmp/trough-segment-manager-server.out 2>&1 &'
 
 script:
 - py.test -v tests

--- a/ansible/roles/trough-sync-server/tasks/main.yml
+++ b/ansible/roles/trough-sync-server/tasks/main.yml
@@ -99,7 +99,7 @@
 - name: Install trough-segment-manager supervised by daemontools in /etc/service
   become: true
   vars:
-    command: "{{venv_root}}/trough-ve3/bin/uwsgi --http :{{sync_server_port}} --uid={{user}} --route-run=chunked: --master --processes=2 --max-requests=50000 --vacuum --die-on-term --http-timeout=900 --mount /=trough.wsgi.segment_manager:server"
+    command: "{{venv_root}}/trough-ve3/bin/uwsgi --http :{{sync_server_port}} --uid={{user}} --master --processes=2 --max-requests=50000 --vacuum --die-on-term --harakiri=7200 --http-timeout=7200 --mount /=trough.wsgi.segment_manager:server"
     name: trough-segment-manager
   template:
     src: service-skeleton.j2

--- a/ansible/roles/trough-worker/tasks/main.yml
+++ b/ansible/roles/trough-worker/tasks/main.yml
@@ -116,7 +116,7 @@
 - name: Install trough-write supervised by daemontools in /etc/service
   become: true
   vars:
-    command: "{{venv_root}}/trough-ve3/bin/uwsgi --http :{{write_port}} --uid={{ user }} --route-run=chunked: --master --processes=2 --harakiri=240 --max-requests=50000 --vacuum --die-on-term --http-timeout=900 --wsgi-file {{venv_root}}/trough-ve3/bin/writer.py"
+    command: "{{venv_root}}/trough-ve3/bin/uwsgi --http :{{write_port}} --uid={{ user }} --master --processes=2 --harakiri=240 --http-timeout=240 --max-requests=50000 --vacuum --die-on-term --http-timeout=900 --wsgi-file {{venv_root}}/trough-ve3/bin/writer.py"
     name: trough-write
   template:
     src: service-skeleton.j2
@@ -154,7 +154,7 @@
 - name: Install trough-read supervised by daemontools in /etc/service
   become: true
   vars:
-    command: "{{venv_root}}/trough-ve3/bin/uwsgi --http :{{read_port}} --uid={{user}} --route-run=chunked: --master --processes=2 --harakiri=3200 --socket-timeout=3200 --max-requests=50000 --vacuum --die-on-term --http-timeout=900 --wsgi-file {{venv_root}}/trough-ve3/bin/reader.py"
+    command: "{{venv_root}}/trough-ve3/bin/uwsgi --http :{{read_port}} --uid={{user}} --master --processes=2 --harakiri=3200 --http-timeout=3200 --socket-timeout=3200 --max-requests=50000 --vacuum --die-on-term --http-timeout=900 --wsgi-file {{venv_root}}/trough-ve3/bin/reader.py"
     name: trough-read
   template:
     src: service-skeleton.j2
@@ -192,7 +192,7 @@
 - name: Install trough-segment-manager-local supervised by daemontools in /etc/service
   become: true
   vars:
-    command: "{{venv_root}}/trough-ve3/bin/uwsgi --http :{{sync_local_port}} --uid={{user}} --route-run=chunked: --master --processes=2 --max-requests=50000 --vacuum --die-on-term --http-timeout=900 --mount /=trough.wsgi.segment_manager:local"
+    command: "{{venv_root}}/trough-ve3/bin/uwsgi --http :{{sync_local_port}} --uid={{user}} --master --processes=2 --max-requests=50000 --vacuum --die-on-term --harakiri=7200 --http-timeout=7200 --mount /=trough.wsgi.segment_manager:local"
     name: trough-segment-manager-local
   template:
     src: service-skeleton.j2

--- a/dev/start-trough-dev.sh
+++ b/dev/start-trough-dev.sh
@@ -45,8 +45,8 @@ while True:
         pass
 "
 
-uwsgi --venv=$VIRTUAL_ENV --http :6444 --route-run=chunked: --master --processes=2 --harakiri=3200 --socket-timeout=3200 --max-requests=50000 --vacuum --die-on-term --wsgi-file $VIRTUAL_ENV/bin/reader.py >>/tmp/trough-read.out 2>&1 &
-uwsgi --venv=$VIRTUAL_ENV --http :6222 --route-run=chunked: --master --processes=2 --harakiri=240 --max-requests=50000 --vacuum --die-on-term --wsgi-file $VIRTUAL_ENV/bin/writer.py >>/tmp/trough-write.out 2>&1 &
+uwsgi --venv=$VIRTUAL_ENV --http :6444 --master --processes=2 --harakiri=3200 --http-timeout=3200 --socket-timeout=3200 --max-requests=50000 --vacuum --die-on-term --wsgi-file $VIRTUAL_ENV/bin/reader.py >>/tmp/trough-read.out 2>&1 &
+uwsgi --venv=$VIRTUAL_ENV --http :6222 --master --processes=2 --harakiri=240 --http-timeout=240 --max-requests=50000 --vacuum --die-on-term --wsgi-file $VIRTUAL_ENV/bin/writer.py >>/tmp/trough-write.out 2>&1 &
 $VIRTUAL_ENV/bin/sync.py --server >>/tmp/trough-sync-server.out 2>&1 &
-uwsgi --venv=$VIRTUAL_ENV --http :6112 --route-run=chunked: --master --processes=2 --harakiri=20 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:local >>/tmp/trough-segment-manager-local.out 2>&1 &
-uwsgi --venv=$VIRTUAL_ENV --http :6111 --route-run=chunked: --master --processes=2 --harakiri=20 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:server >>/tmp/trough-segment-manager-server.out 2>&1 &
+uwsgi --venv=$VIRTUAL_ENV --http :6112 --master --processes=2 --harakiri=7200 --http-timeout=7200 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:local >>/tmp/trough-segment-manager-local.out 2>&1 &
+uwsgi --venv=$VIRTUAL_ENV --http :6111 --master --processes=2 --harakiri=7200 --http-timeout=7200 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:server >>/tmp/trough-segment-manager-server.out 2>&1 &

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -21,9 +21,9 @@ docker run --rm -it --volume="$script_dir/..:/trough" internetarchive/trough-tes
     && bash -x -c "source /tmp/venv/bin/activate \
             && sync.py --server >>/tmp/trough-sync-server.out 2>&1 &" \
     && bash -x -c "source /tmp/venv/bin/activate \
-            && uwsgi --daemonize2 --venv=/tmp/venv --http :6444 --route-run=chunked: --master --processes=2 --harakiri=3200 --socket-timeout=3200 --max-requests=50000 --vacuum --die-on-term --wsgi-file /tmp/venv/bin/reader.py >>/tmp/trough-read.out 2>&1 \
-            && uwsgi --daemonize2 --venv=/tmp/venv --http :6222 --route-run=chunked: --master --processes=2 --harakiri=240 --max-requests=50000 --vacuum --die-on-term --wsgi-file /tmp/venv/bin/writer.py >>/tmp/trough-write.out 2>&1 \
-            && uwsgi --daemonize2 --venv=/tmp/venv --http :6112 --route-run=chunked: --master --processes=2 --harakiri=20 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:local >>/tmp/trough-segment-manager-local.out 2>&1 \
-            && uwsgi --daemonize2 --venv=/tmp/venv --http :6111 --route-run=chunked: --master --processes=2 --harakiri=20 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:server >>/tmp/trough-segment-manager-server.out 2>&1 \
+            && uwsgi --daemonize2 --venv=/tmp/venv --http :6444 --master --processes=2 --harakiri=3200 --http-timeout=3200 --socket-timeout=3200 --max-requests=50000 --vacuum --die-on-term --wsgi-file /tmp/venv/bin/reader.py >>/tmp/trough-read.out 2>&1 \
+            && uwsgi --daemonize2 --venv=/tmp/venv --http :6222 --master --processes=2 --harakiri=240 --http-timeout=240 --max-requests=50000 --vacuum --die-on-term --wsgi-file /tmp/venv/bin/writer.py >>/tmp/trough-write.out 2>&1 \
+            && uwsgi --daemonize2 --venv=/tmp/venv --http :6112 --master --processes=2 --harakiri=7200 --http-timeout=7200 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:local >>/tmp/trough-segment-manager-local.out 2>&1 \
+            && uwsgi --daemonize2 --venv=/tmp/venv --http :6111 --master --processes=2 --harakiri=7200 --max-requests=50000 --vacuum --die-on-term --mount /=trough.wsgi.segment_manager:server >>/tmp/trough-segment-manager-server.out 2>&1 \
             && cd /tmp/trough \
             && py.test -v tests"'


### PR DESCRIPTION
- get rid of --route-run=chunked: option since some responses we
  generate have content-length, and chunking is apparently not required
  even in absence of content-length
- bump up segment manager timeout to fix 500 errors on promotion of large
  segments
- align http-timeout and harakiri