### PR TITLE
update pyyaml dependency so trough works with

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ group: deprecated-2017Q2
 language: python
 python:
 - 2.7
+- 3.7
 - 3.6
 - 3.5
 - 3.4
-- 3.7-dev
+- 3.8-dev
 - nightly
 - pypy
 - pypy3
@@ -16,7 +17,7 @@ matrix:
   - python: pypy
   - python: pypy3
   - python: nightly
-  - python: 3.7-dev
+  - python: 3.8-dev
 
 services:
 - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ group: deprecated-2017Q2
 language: python
 python:
 - 2.7
-- 3.7
+- 3.7-dev
 - 3.6
 - 3.5
 - 3.4

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     ],
     install_requires=[
         'protobuf==3.1.0.post1',
-        'PyYAML==3.12',
+        'PyYAML==3.13',
         'requests==2.18.4',
         'six==1.10.0',
         'snakebite==2.8.2-python3',


### PR DESCRIPTION
python 3.7 (see https://github.com/yaml/pyyaml/issues/126)