### PR TITLE
fix segment promotion path

### DIFF
--- a/tests/wsgi/test_segment_manager.py
+++ b/tests/wsgi/test_segment_manager.py
@@ -278,7 +278,7 @@ def test_promotion(segment_manager_server):
 
     # shouldn't be anything in hdfs yet...
     expected_remote_path = os.path.join(
-            settings['HDFS_PATH'], 'tes', 'test_promotion.sqlite')
+            settings['HDFS_PATH'], 'test_promot', 'test_promotion.sqlite')
     with pytest.raises(FileNotFoundError):
         hdfs.ls(expected_remote_path, detail=True)
 

--- a/trough/sync.py
+++ b/trough/sync.py
@@ -1042,7 +1042,7 @@ class LocalSyncController(SyncController):
                 assignment = self.rethinker.table('assignment').get_all(segment_id, index='segment')[0].run()
                 remote_path = assignment['remote_path']
             except r.errors.ReqlNonExistenceError:
-                remote_path = os.path.join(self.hdfs_path, segment_id[:3], '%s.sqlite' % segment_id)
+                remote_path = os.path.join(self.hdfs_path, segment_id[:-3], '%s.sqlite' % segment_id)
 
             segment = Segment(
                     segment_id, size=-1, rethinker=self.rethinker,


### PR DESCRIPTION
so that ait-seed-12345-job-6789 goes to /trough/ait-seed-12345-job-6
instead of /trough/ait (which becomes a gigantic directory, which is
what we want to avoid)
we are assuming there is entropy at the end of the segment id
this also matches the cold storage path which is important