### PR TITLE
nicer error logging

### DIFF
--- a/trough/write.py
+++ b/trough/write.py
@@ -62,6 +62,6 @@ class WriteServer:
             start_response('200 OK', [('Content-Type', 'text/plain')])
             return output
         except Exception as e:
-            logging.error('500 Server Error due to exception (segment=%r query=%r)', segment, query, exc_info=True)
+            logging.error('500 Server Error due to exception (segment=%r query=%r)', segment, bytes(query), exc_info=True)
             start_response('500 Server Error', [('Content-Type', 'text/plain')])
             return [('500 Server Error: %s\n' % str(e)).encode('utf-8')]


### PR DESCRIPTION
`env('wsgi.input').read()` is evidently returning a list of bytes, e.g.
[105, 110, ...]. No idea why, but it makes the exception logs painful.
Force it to `bytes` for logging.