### PR TITLE
fix "show segments matching" error

### DIFF
--- a/trough/client.py
+++ b/trough/client.py
@@ -198,13 +198,13 @@ class TroughClient(object):
             return None
 
     def readable_segments(self, regex=None):
-        reql = self.rr.table('services', read_mode='outdated').filter(
-                {'role':'trough-read'}).filter(
-                        lambda svc: r.now().sub(
-                            svc['last_heartbeat']).lt(svc['ttl'])
-                        )# .order_by('segment')
+        reql = self.rr.table('services', read_mode='outdated')\
+                .filter({'role':'trough-read'})\
+                .filter(lambda svc: r.now().sub(svc['last_heartbeat'])\
+                                           .lt(svc['ttl']))
         if regex:
-            reql = reql.filter(lambda svc: svc['segment'].match(regex))
+            reql = reql.filter(
+                    lambda svc: svc['segment'].coerce_to('string').match(regex))
         self.logger.debug('querying rethinkdb: %r', reql)
         results = reql.run()
         for result in reql.run():


### PR DESCRIPTION
```
trough> show segments matching ait-seed-.*
2019-10-03 21:51:40,912 DEBUG trough.client.TroughClient.readable_segments(client.py:208) querying rethinkdb: <RethinkerWrapper<RqlQuery instance: r.table('services', read_mode='outdated').filter(r.expr({'role': 'trough-read'})).filter(lambda var_1: ((r.now() - var_1['last_heartbeat']) < var_1['ttl'])).filter(lambda var_2: var_2['segment'].match('ait-seed-.*')) >>
2019-10-03 21:51:49,697 ERROR trough.client.TroughRepl.do_show(__init__.py:180) Expected type STRING but found NUMBER in:
r.table('services', read_mode='outdated').filter(r.expr({'role': 'trough-read'})).filter(lambda var_1: ((r.now() - var_1['last_heartbeat']) < var_1['ttl'])).filter(lambda var_2: var_2['segment'].match('ait-seed-.*'))
                                                                                                                                                                                  ^^^^^^^^^^^^^^^^
Traceback (most recent call last):
  File "/home/nlevitt/workspace/trough/trough/cli/__init__.py", line 177, in do_show
    n_rows = self.display(result)
  File "/home/nlevitt/workspace/trough/trough/cli/__init__.py", line 106, in display
    result = list(result)
  File "/home/nlevitt/workspace/trough/trough/client.py", line 210, in readable_segments
    for result in reql.run():
  File "/home/nlevitt/workspace/trough/trough-ve3/lib/python3.5/site-packages/doublethink/rethinker.py", line 48, in _result_iter
    yield next(result)
  File "/home/nlevitt/workspace/trough/trough-ve3/lib/python3.5/site-packages/rethinkdb/net.py", line 245, in __next__
    return self._get_next(None)
  File "/home/nlevitt/workspace/trough/trough-ve3/lib/python3.5/site-packages/rethinkdb/net.py", line 255, in _get_next
    raise self.error
rethinkdb.errors.ReqlQueryLogicError: Expected type STRING but found NUMBER in:
r.table('services', read_mode='outdated').filter(r.expr({'role': 'trough-read'})).filter(lambda var_1: ((r.now() - var_1['last_heartbeat']) < var_1['ttl'])).filter(lambda var_2: var_2['segment'].match('ait-seed-.*'))
```