### PR TITLE
chore(sentry): adds server-side event filtering

### DIFF
--- a/trough/read.py
+++ b/trough/read.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import trough
-from trough.settings import settings
+from trough.settings import settings, try_init_sentry
 import sqlite3
 import ujson
 import os
@@ -10,12 +10,7 @@ import requests
 import urllib
 import doublethink
 
-if settings['SENTRY_DSN']:
-    try:
-        import sentry_sdk
-        sentry_sdk.init(settings['SENTRY_DSN'])
-    except ImportError:
-        logging.warning("'SENTRY_DSN' setting is configured but 'sentry_sdk' module not available. Install to use sentry.")
+try_init_sentry()
 
 class ReadServer:
     def __init__(self):

--- a/trough/settings.py
+++ b/trough/settings.py
@@ -1,8 +1,11 @@
 import logging
-import yaml
-import sys
 import os
 import socket
+import sys
+
+import snakebite.errors
+import sqlite3
+import yaml
 
 def configure_logging():
     logging.root.handlers = []
@@ -104,3 +107,36 @@ def init_worker():
         logging.info("LOCAL_DATA path %s does not exist. Attempting to make dirs." % settings['LOCAL_DATA'])
         os.makedirs(settings['LOCAL_DATA'])
 
+
+# Exceptions which, if unhandled, will *not* be sent to sentry as events.
+# These exceptions are filtered to reduce excessive event volume from
+# burdenting sentry infrastructure.
+SENTRY_FILTERED_EXCEPTIONS = (
+    snakebite.errors.FileNotFoundException,
+    sqlite3.DatabaseError,
+    sqlite3.OperationalError,
+)
+
+
+def try_init_sentry():
+    """Attempts to initialize the sentry sdk, if available."""
+
+    def _before_send(event, hint):
+        # see: https://docs.sentry.io/platforms/python/configuration/filtering/#event-hints
+        if 'exc_info' in hint:
+            exc_type, exc_value, tb = hint['exc_info']
+            if isinstance(exc_value, SENTRY_FILTERED_EXCEPTIONS):
+                return None
+
+        return event
+
+    sentry_dsn = settings.get('SENTRY_DSN')
+    if sentry_dsn is not None:
+        try:
+            import sentry_sdk
+            sentry_dk.init(sentry_dsn, before_send=_before_send)
+        except ImportError:
+            logging.warning(
+                "'SENTRY_DSN' setting is configured but 'sentry_sdk' module "
+                "not available. Install to use sentry."
+            )

--- a/trough/write.py
+++ b/trough/write.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import trough
-from trough.settings import settings
+from trough.settings import settings, try_init_sentry
 import sqlite3
 import ujson
 import os
@@ -9,12 +9,9 @@ import logging
 import urllib
 import doublethink
 
-if settings['SENTRY_DSN']:
-    try:
-        import sentry_sdk
-        sentry_sdk.init(settings['SENTRY_DSN'])
-    except ImportError:
-        logging.warning("'SENTRY_DSN' setting is configured but 'sentry_sdk' module not available. Install to use sentry.")
+
+try_init_sentry()
+
 
 class WriteServer:
     def __init__(self):


### PR DESCRIPTION
This PR filters three exception-based sentry events, which are apparently account for nearly a million events per day at IA. We're currently using in-sentry filtering to ignore these events but it's almost certain that this has some cost.