### PR TITLE
chore(sentry): adds server-side event filters

### DIFF
--- a/trough/read.py
+++ b/trough/read.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import trough
-from trough.settings import settings
+from trough.settings import settings, try_init_sentry
 import sqlite3
 import ujson
 import os
@@ -10,12 +10,7 @@ import requests
 import urllib
 import doublethink
 
-if settings['SENTRY_DSN']:
-    try:
-        import sentry_sdk
-        sentry_sdk.init(settings['SENTRY_DSN'])
-    except ImportError:
-        logging.warning("'SENTRY_DSN' setting is configured but 'sentry_sdk' module not available. Install to use sentry.")
+try_init_sentry()
 
 class ReadServer:
     def __init__(self):

--- a/trough/settings.py
+++ b/trough/settings.py
@@ -141,7 +141,7 @@ def try_init_sentry():
     if sentry_dsn is not None:
         try:
             import sentry_sdk
-            sentry_dk.init(sentry_dsn, before_send=_before_send)
+            sentry_sdk.init(sentry_dsn, before_send=_before_send)
         except ImportError:
             logging.warning(
                 "'SENTRY_DSN' setting is configured but 'sentry_sdk' module "

--- a/trough/sync.py
+++ b/trough/sync.py
@@ -3,7 +3,7 @@ import abc
 import logging
 import doublethink
 import rethinkdb as r
-from trough.settings import settings, init_worker
+from trough.settings import settings, init_worker, try_init_sentry
 from snakebite import client
 import socket
 import json
@@ -27,12 +27,8 @@ from concurrent import futures
 class ClientError(Exception):
     pass
 
-if settings['SENTRY_DSN']:
-    try:
-        import sentry_sdk
-        sentry_sdk.init(settings['SENTRY_DSN'])
-    except ImportError:
-        logging.warning("'SENTRY_DSN' setting is configured but 'sentry_sdk' module not available. Install to use sentry.")
+
+try_init_sentry()
 
 
 def healthy_services_query(rethinker, role):
@@ -638,7 +634,7 @@ class MasterSyncController(SyncController):
                         logging.info("Removing old assignment to node '%s' for segment [%s]: (%s will be deleted)", assignment.node, segment.id, assignment)
                         self.registry.unassign(assignment)
                         del ring_assignments[dict_key]
-                    ring_assignments[dict_key] = ring_assignments.get(dict_key, Assignment(self.rethinker, d={ 
+                    ring_assignments[dict_key] = ring_assignments.get(dict_key, Assignment(self.rethinker, d={
                                                         'hash_ring': ring.id,
                                                         'node': assigned_node,
                                                         'segment': segment.id,
@@ -772,7 +768,7 @@ class LocalSyncController(SyncController):
     def start(self):
         init_worker()
         self.heartbeat_thread.start()
-        
+
     def heartbeat_periodically_forever(self):
         while True:
             start = time.time()

--- a/trough/write.py
+++ b/trough/write.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import trough
-from trough.settings import settings
+from trough.settings import settings, try_init_sentry
 import sqlite3
 import ujson
 import os
@@ -9,12 +9,9 @@ import logging
 import urllib
 import doublethink
 
-if settings['SENTRY_DSN']:
-    try:
-        import sentry_sdk
-        sentry_sdk.init(settings['SENTRY_DSN'])
-    except ImportError:
-        logging.warning("'SENTRY_DSN' setting is configured but 'sentry_sdk' module not available. Install to use sentry.")
+
+try_init_sentry()
+
 
 class WriteServer:
     def __init__(self):


### PR DESCRIPTION
This PR adds trough server-side event filters for a few common unhandled exceptions that are ultimately filtered on the sentry side. This is being done to reduce the volume of inbound events that are ignored by sentry.