### PR TITLE
Fix three undefined names in db_api.py

### DIFF
--- a/trough/db_api.py
+++ b/trough/db_api.py
@@ -9,6 +9,7 @@ import logging
 from urllib.parse import urlparse, urlencode
 from http.client import HTTPConnection
 import socks
+import sqlparse
 
 def healthy_services_query(rethinker, role):
     return rethinker.table('services').filter({"role": role}).filter(
@@ -130,9 +131,9 @@ class TroughConnection():
     def execute(self, query):
         return self.cursor().execute(query)
     def executemany(self, queries):
-        return self.cursor().executemany(query)
+        return self.cursor().executemany(queries)
     def executescript(self, queries):
-        return self.cursor().executescript(query)
+        return self.cursor().executescript(queries)
     def close(self):
         pass
     def commit(self):


### PR DESCRIPTION
$ `flake8 . --count --select=E9,F63,F7,F82,Y --show-source --statistics`
```
./trough/trough/db_api.py:100:25: F821 undefined name 'sqlparse'
        split_queries = sqlparse.split(queries, encoding=None)
                        ^
./trough/trough/db_api.py:133:42: F821 undefined name 'query'
        return self.cursor().executemany(query)
                                         ^
./trough/trough/db_api.py:135:44: F821 undefined name 'query'
        return self.cursor().executescript(query)
                                           ^
3     F821 undefined name 'sqlparse'
3
```