### PR TITLE
Version update to reflect `master` changes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import glob
 
 setup(
     name='Trough',
-    version='0.1.5',
+    version='0.2.0',
     packages=[
         'trough',
         'trough.shell',


### PR DESCRIPTION
- limit flask requirements; flask>=1.0.2,<2
- limit protobuf version for now; protobuf<4
- Setup named logger, raise log level by default
- correct the number of splits for calling "do_*" functions. correct some docstrings. Add debugging output for "register".
- adds connection error handling with clear error message for connection errors while provisioning segments. This may be responsible for schemaless segments.
- Switched to alternate implementation that preserves file load on import, emits warning on logging configuration
- Setup named logger, raise log level by default