### PR TITLE
fix: do not lazily create SQLite files

### DIFF
--- a/trough/write.py
+++ b/trough/write.py
@@ -26,6 +26,7 @@ class WriteServer:
         if not query:
             raise Exception("No query provided.")
         # no sql parsing, if our chmod has write permission, allow all queries.
+        assert os.path.isfile(segment.local_path())
         connection = sqlite3.connect(segment.local_path())
         trough.sync.setup_connection(connection)
         try:


### PR DESCRIPTION
Add an assertion to stop new files being created with an empty schema if they have not been already provisioned by `local sync`. (Does not catch the 1024 byte empty schema case, if that already exists. By that point it's already too late).